### PR TITLE
Migrate rally-sdk history

### DIFF
--- a/extensions/sdk/.gitignore
+++ b/extensions/sdk/.gitignore
@@ -1,5 +1,3 @@
-/node_modules/
-
 dist/
 
 .DS_Store


### PR DESCRIPTION
I think we should be able to merge over history from the rally-sdk repo, I did this on a github.com/mozilla-rally/rally-sdk clone (with the remote named `old` locally):
```
git checkout -b move-to-mono-repo
mkdir -p extensions/sdk && git add extensions/sdk
# git mv everything to extensions/sdk
git commit -m"prepare to migrate to monorepo"
```

Then to create this branch from the above:
```
git fetch old
git merge -s ours --allow-unrelated-histories old/move-to-mono-repo`
```