### PR TITLE
Save attribution codes based on extension store URL.

### DIFF
--- a/extensions/sdk/src/Rally.ts
+++ b/extensions/sdk/src/Rally.ts
@@ -109,9 +109,9 @@ export class Rally {
    * Attempt to fetch the attribution codes from the store page URL for this extension.
    */
   private async storeAttributionCodes() {
-    const attribution = await browser.storage.local.get("attribution");
+    const attribution = await this.getAttributionCodes();
     if (!(Object.keys(attribution).length === 0 && attribution.constructor === Object)) {
-      console.debug("Attribution codes already set:", attribution);
+      console.debug("Attribution codes already stored");
       return;
     }
 
@@ -150,6 +150,10 @@ export class Rally {
     }
 
     browser.runtime.onMessage.addListener((m, s) => this.handleWebMessage(m, s));
+  }
+
+  private async getAttributionCodes() {
+    return (await browser.storage.local.get("attribution"))["attribution"];
   }
 
   private async processLoggedInUser() {
@@ -339,7 +343,7 @@ export class Rally {
     // information out? Can it be used to mess with studies?
 
     switch (message.type) {
-      case WebMessages.WebCheck:
+      case WebMessages.WebCheck: {
         // The `web-check` message should be safe: any installed extension with
         // the `management` privileges could check for the presence of the
         // Rally SDK and expose that to the web. By exposing this ourselves
@@ -355,9 +359,10 @@ export class Rally {
         }
 
         console.debug("sending web-check-response to sender:", sender, " done");
-        await browser.tabs.sendMessage(sender.tab.id, { type: WebMessages.WebCheckResponse, data: {} });
+        const attribution = await this.getAttributionCodes();
+        await browser.tabs.sendMessage(sender.tab.id, { type: WebMessages.WebCheckResponse, data: { attribution } });
         break;
-
+      }
       case WebMessages.CompleteSignupResponse:
         // The `complete-signup-response` message should be safe: It's a response
         // from the page, containing the credentials from the currently-authenticated user.

--- a/extensions/sdk/src/Rally.ts
+++ b/extensions/sdk/src/Rally.ts
@@ -130,6 +130,9 @@ export class Rally {
     }
 
     const tabs = await browser.tabs.query({ url: storeUrl });
+    if (!(tabs.length > 0)) {
+      throw new Error("No store URLs present in open tabs");
+    }
     const url = new URL(tabs[0].url);
 
     ["source", "medium", "campaign", "term", "content"].forEach((key) => {
@@ -153,7 +156,12 @@ export class Rally {
   }
 
   private async getAttributionCodes() {
-    return (await browser.storage.local.get("attribution"))["attribution"];
+    const attribution = await browser.storage.local.get("attribution");
+    if ("attribution" in attribution) {
+      return attribution["attribution"];
+    } else {
+      return {};
+    }
   }
 
   private async processLoggedInUser() {

--- a/extensions/sdk/src/__tests__/Rally.test.ts
+++ b/extensions/sdk/src/__tests__/Rally.test.ts
@@ -7,11 +7,9 @@ import { doc } from "firebase/firestore";
 import { Rally } from '../Rally';
 import { RunStates } from "../RunStates";
 import { WebMessages } from "../WebMessages";
-import * as chrome from "sinon-chrome/extensions";
+import browser from 'webextension-polyfill';
 
 const FAKE_RALLY_ID = "11f42b4c-8d8e-477e-acd0-b38578228e44";
-
-const flushPromises = () => new Promise(setImmediate);
 
 jest.mock('firebase/app', () => ({
   __esModule: true,
@@ -86,22 +84,13 @@ jest.mock('firebase/firestore', () => ({
   connectFirestoreEmulator: jest.fn()
 }));
 
-// We need to provide the `browser.runtime.id` for sinon-chrome to
-// be happy and play nice with webextension-polyfill. See this issue:
-// https://github.com/mozilla/webextension-polyfill/issues/218
-chrome.runtime.id = "testid";
-global.chrome = chrome;
-
-jest.mock("webextension-polyfill", () => require("sinon-chrome/webextensions"));
-
 describe('Rally SDK', function () {
   beforeEach(() => {
-    chrome.runtime.sendMessage.flush();
-    chrome.runtime.sendMessage.yields();
+    jest.clearAllMocks();
   });
+
   afterEach(() => {
     delete global.fetch;
-    chrome.flush();
   });
 
   async function invokeAuthChangedCallback(rally: Rally, user: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -175,8 +164,9 @@ describe('Rally SDK', function () {
 
     const rallyToken = "...";
     const message = { type: WebMessages.CompleteSignupResponse, data: { rallyToken } };
-    // TODO mock browser.extension.id response
-    const sender = { id: null, url: `http://localhost` };
+    const sender = { id: "test-id", url: `http://localhost` };
+
+    browser.runtime.id = "test-id";
 
     await invokeHandleWebMessage(rally, message, sender);
 
@@ -289,6 +279,48 @@ describe('Rally SDK', function () {
     assert.equal(rally.rallyId, FAKE_RALLY_ID);
 
     // FIXME mock calling onSnapshot
-    await flushPromises();
+    await new Promise(process.nextTick);
+  });
+
+  it('gets attribution code from extension store tab, if present', async function () {
+    browser.storage.local.get = jest.fn().mockReturnValueOnce({});
+    browser.tabs.query = jest.fn().mockReturnValueOnce([{
+      "url": "https://chrome.google.com/webstore/detail/example-study-1?" +
+        "utm_source=test_source&utm_medium=test_medium&utm_campaign=test_campaign&utm_term=test_term&utm_content=test_content"
+    }]);
+
+    new Rally({
+      enableDevMode: false,
+      stateChangeCallback: () => { /**/ },
+      rallySite: "http://localhost",
+      studyId: "exampleStudy1",
+      firebaseConfig: {},
+      enableEmulatorMode: false
+    });
+
+    await new Promise(process.nextTick);
+
+    expect(browser.storage.local.set).toBeCalledWith({
+      "attribution": {
+        "campaign": "test_campaign", "content": "test_content", "medium": "test_medium", "source": "test_source", "term": "test_term"
+      }
+    });
+    expect(browser.storage.local.set).toBeCalledTimes(1);
+  });
+
+  it('does not set attribution code if already set', async function () {
+    browser.storage.local.get = jest.fn().mockReturnValueOnce({ "attribution": {} });
+
+    new Rally({
+      enableDevMode: false,
+      stateChangeCallback: () => { /**/ },
+      rallySite: "http://localhost",
+      studyId: "exampleStudy1",
+      firebaseConfig: {},
+      enableEmulatorMode: false
+    });
+
+    await new Promise(process.nextTick);
+    expect(browser.storage.local.set).toBeCalledTimes(0);
   });
 });

--- a/extensions/sdk/src/rally-content.ts
+++ b/extensions/sdk/src/rally-content.ts
@@ -13,7 +13,7 @@ import { WebMessages } from "./WebMessages";
  *        page. It must have the following structure:
  *        {type: "message-type", data: {...}}
  */
-function sendToPage(message: { type: any; data: { studyId?: string; }; }) { // eslint-disable-line @typescript-eslint/no-explicit-any
+function sendToPage(message: { type: any; data: Record<string, unknown> }) { // eslint-disable-line @typescript-eslint/no-explicit-any
   console.debug(`Rally.sendToPage (content) - sending message ${message.type} to page with data: ${message.data.studyId}`);
 
   switch (message.type) {
@@ -22,7 +22,7 @@ function sendToPage(message: { type: any; data: { studyId?: string; }; }) { // e
       break;
     }
     case WebMessages.WebCheckResponse: {
-      window.dispatchEvent(new CustomEvent(WebMessages.WebCheckResponse, {}));
+      window.dispatchEvent(new CustomEvent(WebMessages.WebCheckResponse, { detail: message.data.attribution }));
       break;
     }
     default: {


### PR DESCRIPTION
Save attribution codes in extension storage when running in non-dev mode, using first AMO/CWS URL present in tabs when the extension calls the Rally constructor for the first time.

Right now this code assumes that the store URL contains a slug matching the studyId, but hyphen-case instead of camelCase. For instance, studyId of facebookPixelHunt would have a CWS URL of https://chrome.google.com/webstore/detail/facebook-pixel-hunt and an AMO URL of https://addons.mozilla.org/addon/facebook-pixel-hunt/

Not asking for review on this yet, I'm [asking in #addons on Matrix](https://matrix.to/#/!CuzZVoCbeoDHsxMCVJ:mozilla.org/$KxX977ulxL3gQoZ-pvIcTJJEUFIQfzMca3I-tVQkW3A?via=mozilla.org&via=matrix.org&via=perthchat.org) if this should work and/or if there are any alternatives, if this is the best/only path forward then I'll figure out how to add tests.

Moved from https://github.com/mozilla-rally/rally-sdk/pull/44