### PR TITLE
Nested studyId in complete signup message and added studyId to web check response

### DIFF
--- a/extensions/sdk/src/Rally.ts
+++ b/extensions/sdk/src/Rally.ts
@@ -312,7 +312,7 @@ export class Rally {
         }
 
         console.debug("sending web-check-response to sender:", sender, " done");
-        await browser.tabs.sendMessage(sender.tab.id, { type: WebMessages.WebCheckResponse, data: {} });
+        await browser.tabs.sendMessage(sender.tab.id, { type: WebMessages.WebCheckResponse, data: { studyId: this._options.studyId } });
         break;
 
       case WebMessages.CompleteSignupResponse:

--- a/extensions/sdk/src/__tests__/Rally.test.ts
+++ b/extensions/sdk/src/__tests__/Rally.test.ts
@@ -90,7 +90,8 @@ jest.mock('firebase/firestore', () => ({
 // be happy and play nice with webextension-polyfill. See this issue:
 // https://github.com/mozilla/webextension-polyfill/issues/218
 chrome.runtime.id = "testid";
-global.chrome = chrome;
+const globalAny: any = global;
+globalAny.chrome = chrome;
 
 jest.mock("webextension-polyfill", () => require("sinon-chrome/webextensions"));
 
@@ -100,7 +101,7 @@ describe('Rally SDK', function () {
     chrome.runtime.sendMessage.yields();
   });
   afterEach(() => {
-    delete global.fetch;
+    delete globalAny.fetch;
     chrome.flush();
   });
 

--- a/extensions/sdk/src/rally-content.ts
+++ b/extensions/sdk/src/rally-content.ts
@@ -18,11 +18,11 @@ function sendToPage(message: { type: any; data: { studyId?: string; }; }) { // e
 
   switch (message.type) {
     case WebMessages.CompleteSignup: {
-      window.dispatchEvent(new CustomEvent(WebMessages.CompleteSignup, { detail: message.data.studyId }));
+      window.dispatchEvent(new CustomEvent(WebMessages.CompleteSignup, { detail: { studyId: message.data.studyId } }));
       break;
     }
     case WebMessages.WebCheckResponse: {
-      window.dispatchEvent(new CustomEvent(WebMessages.WebCheckResponse, {}));
+      window.dispatchEvent(new CustomEvent(WebMessages.WebCheckResponse, { detail: { studyId: message.data.studyId } }));
       break;
     }
     default: {


### PR DESCRIPTION
- Added studyId to web check response
- Nested studyId as a field within complete signup
- Fixed unit tests

Fixes: https://github.com/mozilla-rally/rally/issues/10