### PR TITLE
Make warnings in tests fail again

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -16,8 +16,7 @@
       "name": "test",
       "summary": "Test packages",
       "description": "Runs the unit tests for all projects",
-      "enableParallelism": true,
-      "allowWarningsInSuccessfulBuild": true
+      "enableParallelism": true
     }
     // {
     //   /**

--- a/web-platform/website/package.json
+++ b/web-platform/website/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint -c ../../tools/typescript/.eslintrc.js",
     "format": "prettier --write '**/*.ts[x]' --config ../../tools/typescript/.prettierrc",
-    "test": "jest --silent --verbose",
+    "test": "jest --verbose 2>&1",
     "test:watch": "jest --verbose --watchAll"
   },
   "dependencies": {


### PR DESCRIPTION
Rush intentionally makes tests fail on warnings. We disabled this for Jest, but instead we should keep it enabled and redirect Jest output.

From Rush docs:

> If the command writes anything to the stderr stream, Rush will interpret this to mean that at least one error or warning was reported. This will break the build. (This is by design -- if you allow people to merge PRs that "cry wolf", pretty soon you will find that so many warnings have accumulated that nobody even reads them any more.) Some tooling libraries (e.g. Jest) write to stderr as part of their normal operation; you will need to [redirect their output](https://github.com/microsoft/rushstack-legacy/blob/main/core-build/gulp-core-build/src/tasks/JestReporter.ts#L14).