### PR TITLE
Line up stage, prod firebase configs with rally-web-platform

### DIFF
--- a/web-platform/firebase/firebase.config.rally-web-prod.json
+++ b/web-platform/firebase/firebase.config.rally-web-prod.json
@@ -5,5 +5,6 @@
   "storageBucket": "moz-fx-data-rally-w-prod-dfa4.appspot.com",
   "messagingSenderId": "982322764946",
   "appId": "1:982322764946:web:f9b6aea488cebde47ada4b",
-  "functionsHost": "https://us-central1-moz-fx-data-rally-w-prod-dfa4.cloudfunctions.net"
+  "functionsHost": "https://us-central1-moz-fx-data-rally-w-prod-dfa4.cloudfunctions.net",
+  "measurementId": "G-39T53S2WCJ"
 }

--- a/web-platform/firebase/firebase.config.rally-web-prod.json
+++ b/web-platform/firebase/firebase.config.rally-web-prod.json
@@ -1,6 +1,6 @@
 {
   "apiKey": "AIzaSyAv_gSjNRMbEq3BFCNHPn0soXMCx2IxLeM",
-  "authDomain": "moz-fx-data-rally-w-prod-dfa4.firebaseapp.com",
+  "authDomain": "members.rally.mozilla.org",
   "projectId": "moz-fx-data-rally-w-prod-dfa4",
   "storageBucket": "moz-fx-data-rally-w-prod-dfa4.appspot.com",
   "messagingSenderId": "982322764946",

--- a/web-platform/firebase/firebase.config.rally-web-stage.json
+++ b/web-platform/firebase/firebase.config.rally-web-stage.json
@@ -1,6 +1,6 @@
 {
   "apiKey": "AIzaSyAj3z6_cRdiBzwTuVzey6sJm0hVDVBSrDg",
-  "authDomain": "moz-fx-data-rall-nonprod-ac2a.firebaseapp.com",
+  "authDomain": "members.rally.allizom.org",
   "projectId": "moz-fx-data-rall-nonprod-ac2a",
   "storageBucket": "moz-fx-data-rall-nonprod-ac2a.appspot.com",
   "messagingSenderId": "451372671583",

--- a/web-platform/firebase/firebase.config.rally-web-stage.json
+++ b/web-platform/firebase/firebase.config.rally-web-stage.json
@@ -5,5 +5,6 @@
   "storageBucket": "moz-fx-data-rall-nonprod-ac2a.appspot.com",
   "messagingSenderId": "451372671583",
   "appId": "1:451372671583:web:eeb61e7d7c8ec898f5b1ea",
-  "functionsHost": "https://us-central1-moz-fx-data-rall-nonprod-ac2a.cloudfunctions.net"
+  "functionsHost": "https://us-central1-moz-fx-data-rall-nonprod-ac2a.cloudfunctions.net",
+  "measurementId": "G-LCB133PKPN"
 }


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/DSRE-747

What this PR does:
* changes app authDomains to the desired domains (see changes in rally-web-platform based on a bug rhelmer found & resolved)
* adds measurementIds for Google Analytics to firebase stage & prod configs
* this sends data to 2 new Google Analytics properties in the `Mozilla (Apps + MP + more)` account under the Mozilla Corporation GA organization. javaun, jepstein & marnie have been made admins of both new GA properties (one for prod, one for stage).

Notes:
* This mirrors an update to the rally-web-platform repo as well: https://github.com/mozilla-rally/rally-web-platform/pull/552
* this PR __does not__ setup analytics initialization for the apps - i've included in the linked PR the stock instructions on how to do so from the firebase analytics integration setup, but leave it to yall to review and decide how it fits in yall's app initialization setup.