### PR TITLE
Submit commits to Glean probe-scraper

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -1,0 +1,10 @@
+---
+name: Glean probe-scraper
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  glean-probe-scraper:
+    uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main


### PR DESCRIPTION
to validate and publish metrics, per https://mozilla.github.io/glean/book/user/adding-glean-to-your-project/enable-data-ingestion.html#validate-and-publish-metrics

> After your product has been enabled, you must submit commits to probe scraper to validate and publish metrics. Metrics will only be published from branches defined in probe scraper's repositories.yaml, or the Git default branch if not explicitly configured. This should happen on every CI run to the specified branches. Nightly jobs will then automatically add published metrics to the Glean Dictionary and other data platform tools.