### PR TITLE
Revert "filled in TODOs for bugs, emails and data review"

### DIFF
--- a/extensions/attention-stream/metrics.yaml
+++ b/extensions/attention-stream/metrics.yaml
@@ -27,13 +27,12 @@ rally:
       the Rally SDKs. A value of 00000000-0000-0000-0000-000000000000
       indicates a test payload. A value of 11111111-1111-1111-1111-111111111111
       indicates that the Rally id was not found or properly set.
-    bugs: &bugs
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1778196
-    data_reviews: &data_reviews
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1778367
-    notification_emails: &notification_emails
-      - than@mozilla.com
-      - rhelmer@mozilla.com
+    bugs:
+      - TODO
+    data_reviews:
+      - TODO
+    notification_emails:
+      - TODO
     expires: never
 
 user_journey:
@@ -48,11 +47,11 @@ user_journey:
     send_in_pings:
       - user-journey
     bugs:
-      - *bugs
+      - TODO
     data_reviews:
-      - *data_reviews
+      - TODO
     notification_emails:
-      - *notification_emails
+      - TODO
     expires: never
 
   url:
@@ -63,11 +62,11 @@ user_journey:
     send_in_pings:
       - user-journey
     bugs:
-      - *bugs
+      - TODO
     data_reviews:
-      - *data_reviews
+      - TODO
     notification_emails:
-      - *notification_emails
+      - TODO
     expires: never
 
   referrer:
@@ -78,11 +77,11 @@ user_journey:
     send_in_pings:
       - user-journey
     bugs:
-      - *bugs
+      - TODO
     data_reviews:
-      - *data_reviews
+      - TODO
     notification_emails:
-      - *notification_emails
+      - TODO
     expires: never
 
   page_visit_start_date_time:
@@ -94,11 +93,11 @@ user_journey:
     send_in_pings:
       - user-journey
     bugs:
-      - *bugs
+      - TODO
     data_reviews:
-      - *data_reviews
+      - TODO
     notification_emails:
-      - *notification_emails
+      - TODO
     expires: never
 
   page_visit_stop_date_time:
@@ -110,11 +109,11 @@ user_journey:
     send_in_pings:
       - user-journey
     bugs:
-      - *bugs
+      - TODO
     data_reviews:
-      - *data_reviews
+      - TODO
     notification_emails:
-      - *notification_emails
+      - TODO
     expires: never
 
   attention_duration:
@@ -127,11 +126,11 @@ user_journey:
     send_in_pings:
       - user-journey
     bugs:
-      - *bugs
+      - TODO
     data_reviews:
-      - *data_reviews
+      - TODO
     notification_emails:
-      - *notification_emails
+      - TODO
     expires: never
 
   audio_duration:
@@ -143,11 +142,11 @@ user_journey:
     send_in_pings:
       - user-journey
     bugs:
-      - *bugs
+      - TODO
     data_reviews:
-      - *data_reviews
+      - TODO
     notification_emails:
-      - *notification_emails
+      - TODO
     expires: never
 
   attention_and_audio_duration:
@@ -160,11 +159,11 @@ user_journey:
     send_in_pings:
       - user-journey
     bugs:
-      - *bugs
+      - TODO
     data_reviews:
-      - *data_reviews
+      - TODO
     notification_emails:
-      - *notification_emails
+      - TODO
     expires: never
 
   max_relative_scroll_depth:
@@ -177,9 +176,9 @@ user_journey:
     send_in_pings:
       - user-journey
     bugs:
-      - *bugs
+      - TODO
     data_reviews:
-      - *data_reviews
+      - TODO
     notification_emails:
-      - *notification_emails
+      - TODO
     expires: never

--- a/extensions/attention-stream/pings.yaml
+++ b/extensions/attention-stream/pings.yaml
@@ -13,13 +13,12 @@ study-enrollment:
   description: |
     This ping is sent when the user has consented to the study.
   include_client_id: false
-  bugs: &bugs
-    - https://bugzilla.mozilla.org/show_bug.cgi?id=1778196
-  data_reviews: &data_reviews
-    - https://bugzilla.mozilla.org/show_bug.cgi?id=1778367
-  notification_emails: &notification_emails
-    - than@mozilla.com
-    - rhelmer@mozilla.com
+  bugs:
+    - TODO
+  data_reviews:
+    - TODO
+  notification_emails:
+    - TODO
 
 user-journey:
   description: |
@@ -27,11 +26,11 @@ user-journey:
   include_client_id: false
   send_if_empty: false
   bugs:
-    - *bugs
+    - TODO
   data_reviews:
-    - *data_reviews
+    - TODO
   notification_emails:
-    - *notification_emails
+    - TODO
   reasons:
     page-navigation-observed: |
       Page navigation was observed.


### PR DESCRIPTION
This reverts commit 9fd0b2aeb82ca37f817dcda51bd2f34b6925b487.

@betling this isn't passing Glean's lint so I reverted it for the moment, let's re-do the change in a PR so tests are run. Thanks!

There were a bunch of errors they are all of this form so I think the variable use isn't quite right:

```
==============================================================================
/Users/mozilla/src/rally/extensions/attention-stream/metrics.yaml:
    ```
    user_journey:
      referrer:
        notification_emails:
        - - than@mozilla.com
          - rhelmer@mozilla.com
    ```

    ['than@mozilla.com', 'rhelmer@mozilla.com'] is not of type 'string'
```