### PR TITLE
Allow for different downloadLinks for different browsers

### DIFF
--- a/web-platform/functions/src/studies.ts
+++ b/web-platform/functions/src/studies.ts
@@ -15,8 +15,10 @@ export const studies = {
     chromeExtensionId: "pbeklachfkbjddmglcccopmknmpfchdm",
     studyId: "facebookPixelHunt",
     schemaNamespace: "rally-markup-fb-pixel-hunt",
-    downloadLink:
-      "https://chrome.google.com/webstore/detail/facebook-pixel-hunt/pbeklachfkbjddmglcccopmknmpfchdm",
+    downloadLink: {
+      chrome: "https://chrome.google.com/webstore/detail/facebook-pixel-hunt/pbeklachfkbjddmglcccopmknmpfchdm",
+      firefox: "https://addons.mozilla.org/en-US/firefox/addon/facebook-pixel-hunt/",
+    },
     endDate: "2022-07-13",
     studyEnded: false,
     studyPaused: true,
@@ -48,8 +50,9 @@ export const studies = {
     chromeExtensionId: "bahhehaddofgkccippmjcecepdakppme",
     studyId: "attentionStream",
     schemaNamespace: "rally-attention-stream",
-    downloadLink:
-      "https://chrome.google.com/webstore/detail/attention-stream/bahhehaddofgkccippmjcecepdakppme",
+    downloadLink: {
+      chrome: "https://chrome.google.com/webstore/detail/attention-stream/bahhehaddofgkccippmjcecepdakppme",
+    },
     endDate: "Ongoing",
     studyEnded: false,
     studyPaused: false,


### PR DESCRIPTION
Part of [this issue](https://github.com/mozilla-rally/rally-web-platform/issues/587) on RWP.

Order of operations:
- Land this PR but DONT invoke "loadFirestore"
- Go to the [associated RWP PR](https://github.com/mozilla-rally/rally-web-platform/pull/600), re-run the tests and make sure they pass
- Do our best to a) land the RWP PR and b) invoke the new "loadFirestore" *at the exact same time*
    - the RWP will be **broken** in the interim if one is done but not the other
    
Reviewer:
- sanity check