### PR TITLE
Add Firefox Add-on store downloadLink for the Attention Stream

### DIFF
--- a/web-platform/functions/src/studies.ts
+++ b/web-platform/functions/src/studies.ts
@@ -52,6 +52,7 @@ export const studies = {
     schemaNamespace: "rally-attention-stream",
     downloadLink: {
       chrome: "https://chrome.google.com/webstore/detail/attention-stream/bahhehaddofgkccippmjcecepdakppme",
+      firefox: "https://addons.mozilla.org/en-US/firefox/addon/attention-stream/",
     },
     endDate: "Ongoing",
     studyEnded: false,


### PR DESCRIPTION
Seems like a safe assumption that this will be the link once it goes live.


Adding it now ahead of time so that integration tests for the RWP update can start passing.

NOTE: this will mean that until the extension goes live, Firefox users will click "Add Study Extension" and get sent to a non-existent page. Currently they get sent to the Chrome store so I don't think this is much worse... and hopefully the extension goes live very soon