### PR TITLE
added forget pw screens

### DIFF
--- a/web-platform/website/src/components/pages/account-settings/AccountResetPasswordView.tsx
+++ b/web-platform/website/src/components/pages/account-settings/AccountResetPasswordView.tsx
@@ -1,0 +1,12 @@
+import { Card } from "reactstrap";
+
+import { CardStyles } from "../../../styles/Cards";
+import { ResetPasswordView } from "../login/ResetPasswordView";
+
+export function AcccountResetPasswordView() {
+  return (
+    <Card className={`${CardStyles.account.updates} flex-nowrap`}>
+      <ResetPasswordView isAccount={true} />
+    </Card>
+  );
+}

--- a/web-platform/website/src/components/pages/account-settings/AccountSettingsDataContext.tsx
+++ b/web-platform/website/src/components/pages/account-settings/AccountSettingsDataContext.tsx
@@ -5,6 +5,7 @@ export enum AccountSettingsState {
   EditEmail = "EditEmail",
   EditPassword = "EditPassword",
   DeleteAccount = "DeleteAccount",
+  ResetPassword = "ResetPassword",
 }
 
 export interface AccountSettingsDataContext {

--- a/web-platform/website/src/components/pages/account-settings/AccountSettingsPageContent.tsx
+++ b/web-platform/website/src/components/pages/account-settings/AccountSettingsPageContent.tsx
@@ -4,6 +4,7 @@ import { style } from "typestyle";
 import { Spacing } from "../../../styles";
 import { ContainerStyles } from "../../../styles/ContainerStyles";
 import { Layout } from "../../Layout";
+import { AcccountResetPasswordView } from "./AccountResetPasswordView";
 import {
   AccountSettingsDataContextProvider,
   AccountSettingsState,
@@ -51,6 +52,9 @@ export function AccountSettingsContentFactory() {
 
     case AccountSettingsState.EditPassword:
       return <EditAccountPasswordView />;
+
+    case AccountSettingsState.ResetPassword:
+      return <AcccountResetPasswordView />;
 
     default:
       throw new Error("Invalid account settings state.");

--- a/web-platform/website/src/components/pages/account-settings/DeleteAccountDisclaimer.tsx
+++ b/web-platform/website/src/components/pages/account-settings/DeleteAccountDisclaimer.tsx
@@ -1,6 +1,7 @@
 import { Card, Col, Container, Row } from "reactstrap";
 
 import { Strings } from "../../../resources/Strings";
+import { CardStyles } from "../../../styles/Cards";
 import { ContainerStyles } from "../../../styles/ContainerStyles";
 import {
   AccountSettingsState,
@@ -14,7 +15,7 @@ export function DeleteAccountDisclaimer() {
   const { setAccountSettingsState } = useAccountSettingsDataContext();
 
   return (
-    <Card className="flex-nowrap p-4">
+    <Card className={`${CardStyles.account.default} flex-nowrap p-4`}>
       <Container className={`${ContainerStyles.NoSpacing} p-0`}>
         <Row>
           <Col>

--- a/web-platform/website/src/components/pages/account-settings/EditAccountEmailView.tsx
+++ b/web-platform/website/src/components/pages/account-settings/EditAccountEmailView.tsx
@@ -23,6 +23,7 @@ import {
   TertiaryButton,
   TransparentButton,
 } from "../../../styles/Buttons";
+import { CardStyles } from "../../../styles/Cards";
 import { ContainerStyles } from "../../../styles/ContainerStyles";
 import { FontSizeRaw, Fonts } from "../../../styles/Fonts";
 import { getFirebaseErrorMessage } from "../../../utils/FirebaseErrors";
@@ -79,7 +80,6 @@ export function EditAccountEmailView() {
     setValidationResult(validationResult);
 
     if (!validationResult || !validationResult.valid) {
-      setEyeIconVisible(false);
       if (validationResult.password) {
         if (!validationResult.password.error) {
           const passwordErr =
@@ -97,8 +97,6 @@ export function EditAccountEmailView() {
 
     if (user && user.firebaseUser) {
       if (email == user.firebaseUser.email) {
-        setEyeIconVisible(false);
-
         setValidationResult({
           ...validationResult,
           email: { error: emailErrorStrings.newEmail },
@@ -130,13 +128,11 @@ export function EditAccountEmailView() {
         passwordRules: [],
         valid: false,
       });
-
-      setEyeIconVisible(false);
     }
   }
 
   return (
-    <Card className="flex-nowrap p-4">
+    <Card className={`${CardStyles.account.updates} flex-nowrap`}>
       {confirmationView ? (
         <EmailChangedView email={emailRef.current} />
       ) : (
@@ -152,7 +148,7 @@ export function EditAccountEmailView() {
             <Col>
               <Form>
                 <FormGroup className="mb-4">
-                  <Label for="email" className="fw-bold">
+                  <Label for="email" className={`fw-bold ${Fonts.Labels}`}>
                     {strings.newEmail}
                   </Label>
                   <Input
@@ -179,7 +175,7 @@ export function EditAccountEmailView() {
                 </FormGroup>
 
                 <FormGroup>
-                  <Label for="password" className="fw-bold">
+                  <Label for="password" className={`fw-bold ${Fonts.Labels}`}>
                     {strings.password}
                   </Label>
                   <div className="d-flex flex-row-reverse">
@@ -208,28 +204,36 @@ export function EditAccountEmailView() {
                       )}
                     </div>
 
-                    {eyeIconVisible && (
-                      <img
-                        className="toggle-password align-self-center position-absolute m-1"
-                        src={
-                          !passwordVisible
-                            ? "img/icon-password-show.svg"
-                            : "img/icon-password-hide.svg"
-                        }
-                        alt={passwordVisible ? "open eye" : "eye with slash"}
-                        width="24px"
-                        height="24px"
-                        onClick={() => setPasswordVisible(!passwordVisible)}
-                      />
-                    )}
+                    {eyeIconVisible &&
+                      !isPasswordInvalid &&
+                      !isEmailInvalid && (
+                        <img
+                          className="toggle-password align-self-center position-absolute m-1"
+                          src={
+                            !passwordVisible
+                              ? "img/icon-password-show.svg"
+                              : "img/icon-password-hide.svg"
+                          }
+                          alt={passwordVisible ? "open eye" : "eye with slash"}
+                          width="24px"
+                          height="24px"
+                          onClick={() => setPasswordVisible(!passwordVisible)}
+                        />
+                      )}
                   </div>
                 </FormGroup>
               </Form>
             </Col>
           </Row>
-          <Row className="d-flex justify-content-between">
+          <Row className="d-flex justify-content-between align-items-center">
             <Col className="me-3 col-auto">
-              <Button className={`fw-bold p-0 ${TransparentButton}`} outline>
+              <Button
+                onClick={() =>
+                  setAccountSettingsState(AccountSettingsState.ResetPassword)
+                }
+                className={`p-0 ${TransparentButton}`}
+                outline
+              >
                 {strings.forgot}
               </Button>
             </Col>

--- a/web-platform/website/src/components/pages/account-settings/EditAccountPasswordView.tsx
+++ b/web-platform/website/src/components/pages/account-settings/EditAccountPasswordView.tsx
@@ -25,6 +25,7 @@ import {
   TertiaryButton,
   TransparentButton,
 } from "../../../styles/Buttons";
+import { CardStyles } from "../../../styles/Cards";
 import { ContainerStyles } from "../../../styles/ContainerStyles";
 import { FontSizeRaw, Fonts } from "../../../styles/Fonts";
 import { ToastStyle } from "../../../styles/Toasts";
@@ -175,7 +176,7 @@ export function EditAccountPasswordView() {
   }
 
   return (
-    <Card className="flex-nowrap p-4">
+    <Card className={`${CardStyles.account.updates} flex-nowrap`}>
       <Container
         className={`${ContainerStyles.NoSpacing} ${styles.container} p-0`}
       >
@@ -209,7 +210,10 @@ export function EditAccountPasswordView() {
             <Form>
               {/* *********** CURRENT PASSWORD ********** */}
               <FormGroup>
-                <Label for="currentPassword" className="fw-bold">
+                <Label
+                  for="currentPassword"
+                  className={`fw-bold ${Fonts.Labels}`}
+                >
                   {strings.current}
                 </Label>
                 <div className="d-flex flex-row-reverse">
@@ -264,7 +268,7 @@ export function EditAccountPasswordView() {
 
               {/* ***********NEW PASSWORD ********** */}
               <FormGroup>
-                <Label for="newPassword" className="fw-bold">
+                <Label for="newPassword" className={`fw-bold ${Fonts.Labels}`}>
                   {strings.new}
                 </Label>
                 <div className="d-flex flex-row-reverse">
@@ -319,7 +323,10 @@ export function EditAccountPasswordView() {
 
               {/* *********** CONFIRM PASSWORD ********** */}
               <FormGroup>
-                <Label for="confirmPassword" className="fw-bold">
+                <Label
+                  for="confirmPassword"
+                  className={`fw-bold ${Fonts.Labels}`}
+                >
                   {strings.confirm}
                 </Label>
                 <div className="d-flex flex-row-reverse">
@@ -374,9 +381,15 @@ export function EditAccountPasswordView() {
             </Form>
           </Col>
         </Row>
-        <Row className="d-flex justify-content-between">
+        <Row className="d-flex justify-content-between align-items-center">
           <Col className="me-3 col-auto">
-            <Button className={`fw-bold p-0 ${TransparentButton}`} outline>
+            <Button
+              onClick={() =>
+                setAccountSettingsState(AccountSettingsState.ResetPassword)
+              }
+              className={`p-0 ${TransparentButton}`}
+              outline
+            >
               {strings.forgot}
             </Button>
           </Col>

--- a/web-platform/website/src/components/pages/account-settings/EmailAccountSettings.tsx
+++ b/web-platform/website/src/components/pages/account-settings/EmailAccountSettings.tsx
@@ -2,6 +2,7 @@ import { Card, Col, Container, Row } from "reactstrap";
 
 import { Strings } from "../../../resources/Strings";
 import { useAuthentication } from "../../../services/AuthenticationService";
+import { CardStyles } from "../../../styles/Cards";
 import { ContainerStyles } from "../../../styles/ContainerStyles";
 import {
   AccountSettingsState,
@@ -15,7 +16,7 @@ export function EmailAccountSettings() {
   const { setAccountSettingsState } = useAccountSettingsDataContext();
 
   return (
-    <Card className="flex-nowrap p-4">
+    <Card className={`${CardStyles.account.default} flex-nowrap p-4`}>
       <Container className={`${ContainerStyles.NoSpacing} p-0`}>
         <Row>
           <Col>

--- a/web-platform/website/src/components/pages/account-settings/GoogleAccountSettings.tsx
+++ b/web-platform/website/src/components/pages/account-settings/GoogleAccountSettings.tsx
@@ -3,6 +3,7 @@ import { Card, Col, Container, Row } from "reactstrap";
 import { User } from "../../../models/User";
 import { Strings } from "../../../resources/Strings";
 import { useAuthentication } from "../../../services/AuthenticationService";
+import { CardStyles } from "../../../styles/Cards";
 import { ContainerStyles } from "../../../styles/ContainerStyles";
 import { FontSize } from "../../../styles/Fonts";
 
@@ -24,7 +25,7 @@ export function GoogleAccountSettings() {
   ).toDateString();
 
   return (
-    <Card className="flex-nowrap p-4">
+    <Card className={`${CardStyles.account.default} flex-nowrap`}>
       <Container className={`${ContainerStyles.NoSpacing} p-0`}>
         <Row>
           <Col>

--- a/web-platform/website/src/components/pages/login/ResetPasswordView.tsx
+++ b/web-platform/website/src/components/pages/login/ResetPasswordView.tsx
@@ -23,7 +23,11 @@ import { validateEmailAndReturnError } from "./LoginFormValidator";
 
 const strings = Strings.components.pages.login.resetPasswordView;
 
-export function ResetPasswordView() {
+interface CardLocation {
+  isAccount?: boolean | null;
+}
+
+export function ResetPasswordView({ isAccount = null }: CardLocation) {
   const [email, setEmail] = useState("");
   const [emailSent, setEmailSent] = useState(false);
 
@@ -78,18 +82,21 @@ export function ResetPasswordView() {
       </Row>
       {emailSent ? (
         <>
-          <Row className="mb-5">
-            <Col>
-              <LoginButton
-                className={PrimaryButton}
-                onClick={() => {
-                  setLoginState(LoginState.Login);
-                }}
-              >
-                {strings.postEmailSent.backToSignIn}
-              </LoginButton>
-            </Col>
-          </Row>
+          {!isAccount && (
+            <Row className="mb-5">
+              <Col>
+                <LoginButton
+                  className={PrimaryButton}
+                  onClick={() => {
+                    setLoginState(LoginState.Login);
+                  }}
+                >
+                  {strings.postEmailSent.backToSignIn}
+                </LoginButton>
+              </Col>
+            </Row>
+          )}
+
           <Row>
             <Col className="d-flex justify-content-center">
               <span className={FontSize.Small}>
@@ -124,7 +131,7 @@ export function ResetPasswordView() {
               </Form>
             </Col>
           </Row>
-          <Row className="mb-5">
+          <Row className={`${!isAccount ? "mb-5" : ""}`}>
             <Col>
               <LoginButton
                 className={PrimaryButton}
@@ -134,19 +141,20 @@ export function ResetPasswordView() {
               </LoginButton>
             </Col>
           </Row>
-
-          <Row>
-            <Col className="text-center">
-              {strings.preEmailSent.backTo}{" "}
-              <a
-                className="fw-bold"
-                href="#"
-                onClick={() => setLoginState(LoginState.Login)}
-              >
-                {strings.preEmailSent.signIn}
-              </a>
-            </Col>
-          </Row>
+          {!isAccount && (
+            <Row>
+              <Col className="text-center">
+                {strings.preEmailSent.backTo}{" "}
+                <a
+                  className="fw-bold"
+                  href="#"
+                  onClick={() => setLoginState(LoginState.Login)}
+                >
+                  {strings.preEmailSent.signIn}
+                </a>
+              </Col>
+            </Row>
+          )}
         </>
       )}
     </Container>

--- a/web-platform/website/src/styles/Buttons.ts
+++ b/web-platform/website/src/styles/Buttons.ts
@@ -1,6 +1,6 @@
 import { style } from "typestyle";
-
 import { Colors } from "./Colors";
+import { FontsRaw, FontSizeRaw } from "./Fonts";
 
 export const PrimaryButton = style({
   color: Colors.ColorWhite,
@@ -66,13 +66,15 @@ export const DisabledProductButton = style({
 });
 
 export const TransparentButton = style({
+  ...FontsRaw.MediumBodySM,
   color: Colors.ColorMarketingGray70,
-  borderColor: Colors.ColorTransparent,
+  border: "none",
+  fontSize: FontSizeRaw.Small.fontSize,
   $nest: {
     "&:hover": {
       backgroundColor: Colors.ColorTransparent,
-      borderColor: Colors.ColorTransparent,
       color: Colors.ColorMarketingGray70,
-    },
+      textDecoration: "underline"
+    }
   },
 });

--- a/web-platform/website/src/styles/Cards.ts
+++ b/web-platform/website/src/styles/Cards.ts
@@ -1,0 +1,16 @@
+
+import { style } from "typestyle";
+import { Spacing } from "./Spacing";
+
+export const CardStyles = {
+  account: {
+    default: style({
+      maxWidth: "660px",
+    }),
+    updates: style({
+      maxWidth: "550px",
+      padding: Spacing.xxLarge
+    })
+  }
+
+}

--- a/web-platform/website/src/styles/Fonts.ts
+++ b/web-platform/website/src/styles/Fonts.ts
@@ -1,15 +1,27 @@
 import { style } from "typestyle";
+import {Colors} from "./Colors"
 
 export const FontsRaw = {
   Headline: {
     fontFamily: `"Zilla Slab", Inter, X-LocaleSpecific, sans-serif`,
     fontWeight: 700,
   },
+  MediumBodySM:{
+    fontFamily: 'Inter',
+    fontStyle: "normal",
+    fontWeight: "500",
+  },
+  Labels:{
+    color: Colors.ColorMarketingGray70
+  }
 };
 
 export const Fonts = {
   Headline: style(FontsRaw.Headline),
+  MediumBodySM: style(FontsRaw.MediumBodySM),
+  Labels: style(FontsRaw.Labels)
 };
+
 
 export const FontSizeRaw = {
   xSmall: {


### PR DESCRIPTION
This PR adds the forget password flow to both the change email and password screens in account settings. It also adjusts the size and spacing of the cards to better reflect Casey's designs. 

<img width="1394" alt="Screen Shot 2022-08-24 at 5 30 02 PM" src="https://user-images.githubusercontent.com/88336547/186527174-650c6d0a-501c-4346-b864-9325a113e186.png">

<img width="1385" alt="Screen Shot 2022-08-24 at 5 30 19 PM" src="https://user-images.githubusercontent.com/88336547/186527213-3e684b53-b237-4392-85a7-a801d4852077.png">

<img width="1445" alt="Screen Shot 2022-08-24 at 5 31 13 PM" src="https://user-images.githubusercontent.com/88336547/186527340-8e7d23f8-6935-4671-b232-b900065167b3.png">


Closes #175