### PR TITLE
correct Firefox attribution

### DIFF
--- a/extensions/sdk/src/Rally.ts
+++ b/extensions/sdk/src/Rally.ts
@@ -126,7 +126,7 @@ export class Rally {
 
     const browserInfo = browser.runtime && browser.runtime.getBrowserInfo && await browser.runtime.getBrowserInfo();
 
-    if (browserInfo && browserInfo.name === "firefox") {
+    if (browserInfo && browserInfo.name === "Firefox") {
       storeUrl = `${this._firefoxStoreUrl}/${this._options.storeId}/*`;
     }
 


### PR DESCRIPTION
I found this when testing - [per MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getBrowserInfo), the `name` in `browserInfo` should be `Firefox`, not `firefox`.

No other browsers implement this API, so we consider not matching this to be Chrome for now.