### PR TITLE
updated study cards

### DIFF
--- a/web-platform/website/src/components/pages/studies/StudiesTooltip.tsx
+++ b/web-platform/website/src/components/pages/studies/StudiesTooltip.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, useState } from "react";
+import { HTMLAttributes } from "react";
 import {
   AccordionBody,
   AccordionHeader,
@@ -25,7 +25,7 @@ export function StudiesTooltip({
   className,
   ...rest
 }: HTMLAttributes<HTMLDivElement>) {
-  const [browserType] = useState(detectBrowser());
+  const browserType = detectBrowser();
 
   return (
     <UncontrolledAccordion
@@ -40,19 +40,16 @@ export function StudiesTooltip({
         </AccordionHeader>
         <AccordionBody accordionId="1">
           <ol className={styles.tooltips}>
-            {browserType === BrowserType.Chrome
-              ? strings.sections.map(({ title, text }, i) => (
-                  <li key={i}>
-                    <h1>{title}</h1>
-                    <p>{text}</p>
-                  </li>
-                ))
-              : strings.sections.map(({ title, text, text_fx }, i) => (
-                  <li key={i}>
-                    <h1>{title}</h1>
-                    <p>{i > 0 ? text_fx : text}</p>
-                  </li>
-                ))}
+            {strings.sections.map(({ title, text }, i) => (
+              <li key={i}>
+                <h1>{title}</h1>
+                <p>
+                  {browserType === BrowserType.Chrome
+                    ? text.chrome
+                    : text.firefox}
+                </p>
+              </li>
+            ))}
           </ol>
         </AccordionBody>
       </AccordionItem>

--- a/web-platform/website/src/components/pages/studies/StudiesTooltip.tsx
+++ b/web-platform/website/src/components/pages/studies/StudiesTooltip.tsx
@@ -25,9 +25,7 @@ export function StudiesTooltip({
   className,
   ...rest
 }: HTMLAttributes<HTMLDivElement>) {
-
   const [browserType] = useState(detectBrowser());
-
 
   return (
     <UncontrolledAccordion
@@ -42,24 +40,19 @@ export function StudiesTooltip({
         </AccordionHeader>
         <AccordionBody accordionId="1">
           <ol className={styles.tooltips}>
-            {
-              browserType === BrowserType.Chrome
-                ?
-                strings.sections.map(({ title, text }, i) => (
+            {browserType === BrowserType.Chrome
+              ? strings.sections.map(({ title, text }, i) => (
                   <li key={i}>
                     <h1>{title}</h1>
                     <p>{text}</p>
                   </li>
                 ))
-
-                :
-                strings.sections.map(({ title, text, text_fx }, i) => (
+              : strings.sections.map(({ title, text, text_fx }, i) => (
                   <li key={i}>
                     <h1>{title}</h1>
                     <p>{i > 0 ? text_fx : text}</p>
                   </li>
-                ))
-            }
+                ))}
           </ol>
         </AccordionBody>
       </AccordionItem>

--- a/web-platform/website/src/components/pages/studies/StudiesTooltip.tsx
+++ b/web-platform/website/src/components/pages/studies/StudiesTooltip.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from "react";
+import { HTMLAttributes, useState } from "react";
 import {
   AccordionBody,
   AccordionHeader,
@@ -15,6 +15,8 @@ import {
   createResponsiveStyle,
 } from "../../../styles";
 import { StandardAccordion } from "../../../styles/Accordions";
+import { detectBrowser } from "../../../utils/BrowserDetector";
+import { BrowserType } from "../../../utils/BrowserType";
 
 const strings = Strings.components.pages.studies.tooltip;
 
@@ -23,6 +25,10 @@ export function StudiesTooltip({
   className,
   ...rest
 }: HTMLAttributes<HTMLDivElement>) {
+
+  const [browserType] = useState(detectBrowser());
+
+
   return (
     <UncontrolledAccordion
       defaultOpen="1"
@@ -36,12 +42,24 @@ export function StudiesTooltip({
         </AccordionHeader>
         <AccordionBody accordionId="1">
           <ol className={styles.tooltips}>
-            {strings.sections.map(({ title, text }, i) => (
-              <li key={i}>
-                <h1>{title}</h1>
-                <p>{text}</p>
-              </li>
-            ))}
+            {
+              browserType === BrowserType.Chrome
+                ?
+                strings.sections.map(({ title, text }, i) => (
+                  <li key={i}>
+                    <h1>{title}</h1>
+                    <p>{text}</p>
+                  </li>
+                ))
+
+                :
+                strings.sections.map(({ title, text, text_fx }, i) => (
+                  <li key={i}>
+                    <h1>{title}</h1>
+                    <p>{i > 0 ? text_fx : text}</p>
+                  </li>
+                ))
+            }
           </ol>
         </AccordionBody>
       </AccordionItem>

--- a/web-platform/website/src/components/pages/studies/__tests__/StudiesTooltip.tests.tsx
+++ b/web-platform/website/src/components/pages/studies/__tests__/StudiesTooltip.tests.tsx
@@ -13,10 +13,10 @@ describe("StudiesTooltip tests", () => {
     expect(root.getByText(strings.title)).toBeInTheDocument();
 
     strings.sections.forEach(({ text, title }) => {
-      if (typeof text === "string") {
-        expect(root.getByText(text)).toBeInTheDocument();
+      if (typeof text.chrome === "string") {
+        expect(root.getByText(text.chrome)).toBeInTheDocument();
       } else {
-        expect(React.isValidElement(text)).toBeTruthy();
+        expect(React.isValidElement(text.chrome)).toBeTruthy();
       }
 
       expect(root.getByText(title)).toBeInTheDocument();

--- a/web-platform/website/src/components/pages/studies/study-card/StudyCardHeader.tsx
+++ b/web-platform/website/src/components/pages/studies/study-card/StudyCardHeader.tsx
@@ -42,9 +42,8 @@ export function StudyCardHeader() {
   return (
     <>
       <Container
-        className={`${styles.container} ${
-          isInstalledAndConnected ? "joinAndConnected" : "notJoined"
-        }`}
+        className={`${styles.container} ${isInstalledAndConnected ? "joinAndConnected" : "notJoined"
+          }`}
       >
         <Row className="d-flex align-items-center">
           <Col className="col-auto">
@@ -72,7 +71,10 @@ export function StudyCardHeader() {
                 className="fw-bold"
                 style={{ color: Colors.ColorBlue50 }}
               >
-                {strings.addExtension}
+                {browserType === BrowserType.Chrome
+                  ? strings.addExtension
+                  : strings.addExtension_fx
+                }
               </a>
             ) : (
               <></>

--- a/web-platform/website/src/components/pages/studies/study-card/StudyCardHeader.tsx
+++ b/web-platform/website/src/components/pages/studies/study-card/StudyCardHeader.tsx
@@ -73,8 +73,8 @@ export function StudyCardHeader() {
                 style={{ color: Colors.ColorBlue50 }}
               >
                 {browserType === BrowserType.Chrome
-                  ? strings.addExtension
-                  : strings.addExtension_fx}
+                  ? strings.addExtension.chrome
+                  : strings.addExtension.firefox}
               </a>
             ) : (
               <></>

--- a/web-platform/website/src/components/pages/studies/study-card/StudyCardHeader.tsx
+++ b/web-platform/website/src/components/pages/studies/study-card/StudyCardHeader.tsx
@@ -42,8 +42,9 @@ export function StudyCardHeader() {
   return (
     <>
       <Container
-        className={`${styles.container} ${isInstalledAndConnected ? "joinAndConnected" : "notJoined"
-          }`}
+        className={`${styles.container} ${
+          isInstalledAndConnected ? "joinAndConnected" : "notJoined"
+        }`}
       >
         <Row className="d-flex align-items-center">
           <Col className="col-auto">
@@ -73,8 +74,7 @@ export function StudyCardHeader() {
               >
                 {browserType === BrowserType.Chrome
                   ? strings.addExtension
-                  : strings.addExtension_fx
-                }
+                  : strings.addExtension_fx}
               </a>
             ) : (
               <></>

--- a/web-platform/website/src/components/pages/studies/study-card/__tests__/StudyCardHeader.tests.tsx
+++ b/web-platform/website/src/components/pages/studies/study-card/__tests__/StudyCardHeader.tests.tsx
@@ -45,10 +45,10 @@ describe("StudyCardHeader tests", () => {
       })
     ).toBeDefined();
 
-    expect(root.getByText(strings.addExtension)).toBeInTheDocument();
+    expect(root.getByText(strings.addExtension.chrome)).toBeInTheDocument();
 
     expect(document.querySelector(`a[href="download.com"]`)?.innerHTML).toBe(
-      strings.addExtension
+      strings.addExtension.chrome
     );
 
     expect(root.getByText(strings.menus.dontJoinStudy)).toBeInTheDocument();
@@ -71,7 +71,7 @@ describe("StudyCardHeader tests", () => {
       })
     ).toBeDefined();
 
-    expect(root.queryByText(strings.addExtension)).not.toBeInTheDocument();
+    expect(root.queryByText(strings.addExtension.chrome)).not.toBeInTheDocument();
 
     expect(
       root.queryByText(strings.menus.dontJoinStudy)

--- a/web-platform/website/src/resources/Strings.tsx
+++ b/web-platform/website/src/resources/Strings.tsx
@@ -1087,9 +1087,9 @@ export const Strings = {
               ),
               text_fx: (
                 <>
-                  In the Firefox Adds-ons Store, click on the <b>Add to Firefox</b>{" "}
-                  button. This will add the study's extension to your browser.
-                  You are now participating!
+                  In the Firefox Adds-ons Store, click on the{" "}
+                  <b>Add to Firefox</b> button. This will add the study's
+                  extension to your browser. You are now participating!
                 </>
               ),
             },

--- a/web-platform/website/src/resources/Strings.tsx
+++ b/web-platform/website/src/resources/Strings.tsx
@@ -1030,8 +1030,10 @@ export const Strings = {
             title: "Leave this Study?",
           },
           header: {
-            addExtension: "Add study extension from the Chrome Web Store.",
-            addExtension_fx: "Add study extension from the Firefox store.",
+            addExtension: {
+              chrome: "Add study extension from the Chrome Web Store.",
+              firefox: "Add study extension from the Firefox Store.",
+            },
             participating: "You're participating.",
             notParticipatingYet: "You're not participating yet. ",
             menus: {
@@ -1057,41 +1059,52 @@ export const Strings = {
           sections: [
             {
               title: "Read the study card",
-              text: "The card discloses the data we collect from you, who has access to the data, and how it will be used.",
+              text: {
+                chrome:
+                  "The card discloses the data we collect from you, who has access to the data, and how it will be used.",
+                firefox:
+                  "The card discloses the data we collect from you, who has access to the data, and how it will be used.",
+              },
             },
             {
               title: "Join the Study",
-              text: (
-                <>
-                  Click the <b>Join Study</b> button. We'll ask you to confirm
-                  in a pop-up dialog by clicking the <b>Add Study Extension</b>{" "}
-                  button. This will open up the Chrome Web Store.
-                </>
-              ),
-              text_fx: (
-                <>
-                  Click the <b>Join Study</b> button. We'll ask you to confirm
-                  in a pop-up dialog by clicking the <b>Add Study Extension</b>{" "}
-                  button. This will open up the Firefox Adds-ons Store.
-                </>
-              ),
+              text: {
+                chrome: (
+                  <>
+                    Click the <b>Join Study</b> button. We'll ask you to confirm
+                    in a pop-up dialog by clicking the{" "}
+                    <b>Add Study Extension</b> button. This will open up the
+                    Chrome Web Store.
+                  </>
+                ),
+                firefox: (
+                  <>
+                    Click the <b>Join Study</b> button. We'll ask you to confirm
+                    in a pop-up dialog by clicking the{" "}
+                    <b>Add Study Extension</b> button. This will open up the
+                    Firefox Adds-ons Store.
+                  </>
+                ),
+              },
             },
             {
               title: "Add study extension",
-              text: (
-                <>
-                  In the Chrome Web Store, click on the <b>Add to Chrome</b>{" "}
-                  button. This will add the study's extension to your browser.
-                  You are now participating!
-                </>
-              ),
-              text_fx: (
-                <>
-                  In the Firefox Adds-ons Store, click on the{" "}
-                  <b>Add to Firefox</b> button. This will add the study's
-                  extension to your browser. You are now participating!
-                </>
-              ),
+              text: {
+                chrome: (
+                  <>
+                    In the Chrome Web Store, click on the <b>Add to Chrome</b>{" "}
+                    button. This will add the study's extension to your browser.
+                    You are now participating!
+                  </>
+                ),
+                firefox: (
+                  <>
+                    In the Firefox Adds-ons Store, click on the{" "}
+                    <b>Add to Firefox</b> button. This will add the study's
+                    extension to your browser. You are now participating!
+                  </>
+                ),
+              },
             },
           ],
           title: "How to join a study",

--- a/web-platform/website/src/resources/Strings.tsx
+++ b/web-platform/website/src/resources/Strings.tsx
@@ -1031,6 +1031,7 @@ export const Strings = {
           },
           header: {
             addExtension: "Add study extension from the Chrome Web Store.",
+            addExtension_fx: "Add study extension from the Firefox store.",
             participating: "You're participating.",
             notParticipatingYet: "You're not participating yet. ",
             menus: {
@@ -1067,12 +1068,26 @@ export const Strings = {
                   button. This will open up the Chrome Web Store.
                 </>
               ),
+              text_fx: (
+                <>
+                  Click the <b>Join Study</b> button. We'll ask you to confirm
+                  in a pop-up dialog by clicking the <b>Add Study Extension</b>{" "}
+                  button. This will open up the Firefox Adds-ons Store.
+                </>
+              ),
             },
             {
               title: "Add study extension",
               text: (
                 <>
                   In the Chrome Web Store, click on the <b>Add to Chrome</b>{" "}
+                  button. This will add the study's extension to your browser.
+                  You are now participating!
+                </>
+              ),
+              text_fx: (
+                <>
+                  In the Firefox Adds-ons Store, click on the <b>Add to Firefox</b>{" "}
                   button. This will add the study's extension to your browser.
                   You are now participating!
                 </>


### PR DESCRIPTION
This PR changes the copy on the cards for each browser (firefox and chrome):

**Firefox:**
![Screen Shot 2022-09-20 at 1 06 14 PM](https://user-images.githubusercontent.com/88336547/191321193-df961d73-6551-4164-b29a-159b71e091d3.png)


**Chrome:**
![Screen Shot 2022-09-20 at 1 11 44 PM](https://user-images.githubusercontent.com/88336547/191321942-06f537e7-b7bc-43ab-80b8-4bc6ae6eccf1.png)



closes #243 