### PR TITLE
switch from tsx to tsnode, to avoid esbuild breakage on older npm

### DIFF
--- a/extensions/attention-stream/package.json
+++ b/extensions/attention-stream/package.json
@@ -2,8 +2,8 @@
   "name": "rally-attention-stream",
   "version": "0.5.0",
   "scripts": {
-    "config:chrome": "tsx scripts/generate-manifest.ts --browser=chrome --manifest-version=3",
-    "config:firefox": "tsx scripts/generate-manifest.ts --browser=firefox --manifest-version=2",
+    "config:chrome": "ts-node scripts/generate-manifest.ts --browser=chrome --manifest-version=3",
+    "config:firefox": "ts-node scripts/generate-manifest.ts --browser=firefox --manifest-version=2",
     "build": "npm run config:chrome && npm run build:glean && rollup -c 2>&1 && npm run tailwind && npm run package",
     "dev": "npm run config:chrome && npm run build:glean && npm run clean && npm run tailwind && npm run dev:extension",
     "dev:extension": "rollup -c --config-enable-developer-mode -w --watch.onEnd \"npm run dev:webext\"",
@@ -63,7 +63,8 @@
     "pako": "^2.0.4",
     "semver": "~7.3.7",
     "tailwindcss": "^3.0.24",
-    "webextension-polyfill": "^0.8.0"
+    "webextension-polyfill": "^0.8.0",
+    "ts-node": "~10.9.1"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/extensions/attention-stream/package.json
+++ b/extensions/attention-stream/package.json
@@ -52,7 +52,6 @@
     "rollup-plugin-copy": "^3.4.0",
     "selenium-webdriver": "^4.1.1",
     "ts-jest": "^28.0.2",
-    "tsx": "^3.9.0",
     "typescript": "^4.6.4",
     "web-ext": "^7.0.0"
   },
@@ -62,9 +61,9 @@
     "@mozilla/web-science": "^0.5.3",
     "dexie": "^3.2.2",
     "pako": "^2.0.4",
+    "semver": "~7.3.7",
     "tailwindcss": "^3.0.24",
-    "webextension-polyfill": "^0.8.0",
-    "semver": "~7.3.7"
+    "webextension-polyfill": "^0.8.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/extensions/attention-stream/package.json
+++ b/extensions/attention-stream/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rally-attention-stream",
   "version": "0.5.0",
+  "type": "module",
   "scripts": {
-    "config:chrome": "ts-node scripts/generate-manifest.ts --browser=chrome --manifest-version=3",
-    "config:firefox": "ts-node scripts/generate-manifest.ts --browser=firefox --manifest-version=2",
+    "config:chrome": "ts-node-esm scripts/generate-manifest.ts --browser=chrome --manifest-version=3 2>&1",
+    "config:firefox": "ts-node-esm scripts/generate-manifest.ts --browser=firefox --manifest-version=2 2>&1",
     "build": "npm run config:chrome && npm run build:glean && rollup -c 2>&1 && npm run tailwind && npm run package",
     "dev": "npm run config:chrome && npm run build:glean && npm run clean && npm run tailwind && npm run dev:extension",
     "dev:extension": "rollup -c --config-enable-developer-mode -w --watch.onEnd \"npm run dev:webext\"",

--- a/extensions/attention-stream/scripts/generate-manifest.ts
+++ b/extensions/attention-stream/scripts/generate-manifest.ts
@@ -1,7 +1,9 @@
-import manifestTemplate from "../manifest-template.json";
+import manifestTemplate from "../manifest-template.json" assert { type: "json" };
 import fs from "fs/promises";
 import minimist from "minimist";
-import { sys } from "typescript";
+import pkg from "typescript";
+const { sys } = pkg;
+
 
 const args = minimist(process.argv.slice(2));
 

--- a/extensions/attention-stream/tsconfig.json
+++ b/extensions/attention-stream/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"moduleResolution": "node",
-		"module": "es2020",
+		"module": "esnext",
 		"lib": ["es2020", "DOM"],
 		"target": "es2019",
 		/**

--- a/extensions/attention-stream/web-ext-config.cjs
+++ b/extensions/attention-stream/web-ext-config.cjs
@@ -31,7 +31,7 @@ module.exports = {
     "package.json",
     "README.md",
     "rollup.config.*",
-    "web-ext-config.js",
+    "web-ext-config.cjs",
     "public/**/*.map",
     "tsconfig.json",
     "babel.config.cjs",


### PR DESCRIPTION
Rush only supports older versions of npm, and unfortunately the esbuild that comes with tsx seems to break things.

We should consider moving to pnpm or yarn, but in the meantime work around by switching from tsx to ts-node.