### PR TITLE
Pass utm codes to download links

### DIFF
--- a/web-platform/website/src/pages/_app.tsx
+++ b/web-platform/website/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
+import { AttributionProvider } from "../services/AttributionService";
 import { AuthenticationProvider } from "../services/AuthenticationService";
 import { useFirebase } from "../services/FirebaseService";
 import { StudiesProvider } from "../services/StudiesService";
@@ -48,13 +49,15 @@ function MyApp({ Component, pageProps }: AppProps) {
           crossOrigin="anonymous"
         />
       </Head>
-      <AuthenticationProvider>
-        <StudiesProvider>
-          <UserDocumentProvider>
-            <Component {...pageProps} />
-          </UserDocumentProvider>
-        </StudiesProvider>
-      </AuthenticationProvider>
+      <AttributionProvider>
+        <AuthenticationProvider>
+          <StudiesProvider>
+            <UserDocumentProvider>
+              <Component {...pageProps} />
+            </UserDocumentProvider>
+          </StudiesProvider>
+        </AuthenticationProvider>
+      </AttributionProvider>
     </>
   );
 }

--- a/web-platform/website/src/services/AttributionService.tsx
+++ b/web-platform/website/src/services/AttributionService.tsx
@@ -1,0 +1,80 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+export interface AttributionDataContext {
+  // Attribution codes from local storage.
+  allAttributionCodes: URLSearchParams;
+
+  // Loading flag for all attribution info.
+  isLoaded: boolean;
+
+  // Set attribution codes in query string of a provided URL.
+  setAttributionCodes(url: URL): URL;
+}
+
+const AttributionContext = createContext<AttributionDataContext>(
+  {} as AttributionDataContext
+);
+
+export function useAttribution() {
+  return useContext(AttributionContext);
+}
+
+export function AttributionProvider(props: { children: React.ReactNode }) {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [allAttributionCodes, setAllAttributionCodes] =
+    useState<URLSearchParams>(new URLSearchParams());
+
+  async function loadAllAttributionCodes() {
+    // Add UTM codes to store links, if present.
+    let utmParams = new URLSearchParams();
+    if (typeof window !== "undefined") {
+      const utmKeys = ["source", "medium", "campaign", "term", "content"];
+
+      // Use "last-click" attribution, overwriting any stored UTM codes if new ones are encountered.
+      const storedParams = window.localStorage.getItem("rally_utm");
+      if (storedParams) {
+        utmParams = new URLSearchParams(storedParams);
+      }
+
+      const searchParams = new URL(window.location.href).searchParams;
+      utmKeys.forEach((key) => {
+        const utmKey = `utm_${key}`;
+        searchParams.has(utmKey) &&
+          utmParams.set(utmKey, searchParams.get(utmKey) ?? "");
+      });
+      window.localStorage.setItem("rally_utm", utmParams.toString());
+    }
+    setAllAttributionCodes(utmParams);
+
+    setIsLoaded(true);
+  }
+
+  function setAttributionCodes(url: URL) {
+    const returnUrl = new URL(url.href);
+
+    if (typeof window !== "undefined") {
+      const utmParams = new URLSearchParams(
+        window.localStorage.getItem("rally_utm") ?? ""
+      );
+      ["source", "medium", "campaign", "term", "content"].forEach((key) => {
+        const utmKey = `utm_${key}`;
+        if (utmParams.has(utmKey)) {
+          returnUrl.searchParams.set(utmKey, utmParams.get(utmKey) ?? "");
+        }
+      });
+    }
+
+    return returnUrl;
+
+  }
+
+  useEffect(() => {
+    loadAllAttributionCodes();
+  }, []);
+
+  return (
+    <AttributionContext.Provider value={{ isLoaded, allAttributionCodes, setAttributionCodes }}>
+      {props.children}
+    </AttributionContext.Provider>
+  );
+}

--- a/web-platform/website/src/services/__tests__/AttributionService.tests.tsx
+++ b/web-platform/website/src/services/__tests__/AttributionService.tests.tsx
@@ -1,0 +1,75 @@
+import { RenderResult, act, render } from "@testing-library/react";
+
+import {
+  AttributionDataContext,
+  AttributionProvider,
+  useAttribution,
+} from "../AttributionService";
+
+const attributionQueryString =
+  "?utm_source=test-source" +
+  "&utm_medium=test-medium" +
+  "&utm_campaign=test-campaign" +
+  "&utm_term=test-term" +
+  "&utm_content=test-content";
+
+describe("AttributionService tests", () => {
+  it("loads the attribution codes correctly", async () => {
+    let attributionContext: AttributionDataContext =
+      null as unknown as AttributionDataContext;
+
+    function Component() {
+      attributionContext = useAttribution();
+      return null;
+    }
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: `https://example.com/${attributionQueryString}`
+      }
+    });
+
+    jest.spyOn(Storage.prototype, 'getItem');
+
+    const renderedComponent = (
+      <AttributionProvider>
+        <Component />
+      </AttributionProvider>
+    );
+
+    let root = null as unknown as RenderResult;
+
+    await act(async () => {
+      root = render(renderedComponent);
+    });
+
+    const testUrl = new URL("https://example.com");
+
+    // No attribution codes in local storage, should be pulled from the URL in window.location
+    const result = attributionContext.setAttributionCodes(testUrl);
+    expect(attributionContext).not.toBeNull();
+    expect(result.href).toEqual(`https://example.com/${attributionQueryString}`);
+
+    expect(localStorage.getItem).toHaveBeenCalledWith("rally_utm");
+
+    // Attribution codes already present in local storage.
+    Storage.prototype.getItem = jest.fn(
+      (name) => {
+        if (name === "rally_utm") {
+          return { utm_source: "test" };
+        }
+      }
+    );
+    const result2 = attributionContext.setAttributionCodes(testUrl);
+    expect(attributionContext).not.toBeNull();
+    expect(result2.href).toEqual(`https://example.com/?utm_source=test`);
+
+    expect(localStorage.getItem).toHaveBeenCalledWith("rally_utm");
+
+
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});


### PR DESCRIPTION
The members site should store any inbound UTM codes in local storage, and set these on outbound links to the CWS and AMO extension stores.

Fixes https://github.com/mozilla-rally/rally/issues/268