### PR TITLE
Update studies.ts

### DIFF
--- a/web-platform/functions/src/studies.ts
+++ b/web-platform/functions/src/studies.ts
@@ -51,7 +51,7 @@ export const studies = {
     studyId: "attentionStream",
     schemaNamespace: "rally-attention-stream",
     downloadLink: {
-      chrome: "https://chrome.google.com/webstore/detail/rally-attention-stream/bahhehaddofgkccippmjcecepdakppme",
+      chrome: "https://chrome.google.com/webstore/detail/mozilla-rally/bahhehaddofgkccippmjcecepdakppme",
       firefox: "https://addons.mozilla.org/en-US/firefox/addon/rally-attention-stream",
     },
     endDate: "Ongoing",


### PR DESCRIPTION
The Chrome store URL changed (due to Attention Stream -> Mozilla Rally rename) and is now https://chrome.google.com/webstore/detail/mozilla-rally/bahhehaddofgkccippmjcecepdakppme