### PR TITLE
Fix attribution pings

### DIFF
--- a/extensions/attention-stream/manifest-template.json
+++ b/extensions/attention-stream/manifest-template.json
@@ -2,7 +2,7 @@
   "description": "The Mozilla Rally extension for data collection",
   "author": "Mozilla",
   "name": "Mozilla Rally",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "homepage_url": "https://github.com/mozilla-rally/rally",
   "options_ui": {
     "page": "public/options.html",

--- a/extensions/attention-stream/package.json
+++ b/extensions/attention-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rally-extension",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "config:chrome": "ts-node-esm scripts/generate-manifest.ts --browser=chrome --manifest-version=3 2>&1",

--- a/extensions/sdk/src/Rally.ts
+++ b/extensions/sdk/src/Rally.ts
@@ -182,7 +182,7 @@ export class Rally {
   }
 
   async getAttributionCodes() {
-    const attribution = await browser.storage.local.get();
+    const attribution = await browser.storage.local.get(null);
     return (attribution && attribution["attribution"]) || {};
   }
 

--- a/extensions/sdk/src/Rally.ts
+++ b/extensions/sdk/src/Rally.ts
@@ -182,7 +182,7 @@ export class Rally {
   }
 
   async getAttributionCodes() {
-    const attribution = await browser.storage.local.get({});
+    const attribution = await browser.storage.local.get();
     return (attribution && attribution["attribution"]) || {};
   }
 

--- a/extensions/sdk/src/__tests__/Rally.test.ts
+++ b/extensions/sdk/src/__tests__/Rally.test.ts
@@ -124,7 +124,7 @@ describe("Rally SDK", function () {
 
   it("does not jump to new tab when Rally website is not loaded", async function () {
     // Suppress error printing
-    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => { });
 
     const rally = new Rally({
       enableDevMode: false,
@@ -407,16 +407,22 @@ describe("Rally SDK", function () {
 
     await new Promise(process.nextTick);
 
-    expect(browser.storage.local.set).toBeCalledWith({
+    const expectedResult = {
       attribution: {
         campaign: "test_campaign",
         content: "test_content",
         medium: "test_medium",
         source: "test_source",
         term: "test_term",
-      },
-    });
+      }
+    };
+
+    expect(browser.storage.local.set).toBeCalledWith(expectedResult);
     expect(browser.storage.local.set).toBeCalledTimes(1);
+
+    // Ensure that getter returns the correct result as well.
+    const result = await rally.getAttributionCodes();
+    expect(result).toEqual(expectedResult)
 
     rally.shutdown();
   });
@@ -431,7 +437,7 @@ describe("Rally SDK", function () {
     };
 
     // Suppress error printing
-    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => { });
 
     browser.tabs.query = jest.fn().mockReturnValueOnce([]);
     browser.storage.local.get = jest.fn().mockReturnValueOnce({ attribution });

--- a/extensions/sdk/src/__tests__/Rally.test.ts
+++ b/extensions/sdk/src/__tests__/Rally.test.ts
@@ -420,9 +420,11 @@ describe("Rally SDK", function () {
     expect(browser.storage.local.set).toBeCalledWith(expectedResult);
     expect(browser.storage.local.set).toBeCalledTimes(1);
 
+    browser.storage.local.get = jest.fn().mockReturnValueOnce(expectedResult);
+
     // Ensure that getter returns the correct result as well.
     const result = await rally.getAttributionCodes();
-    expect(result).toEqual(expectedResult)
+    expect(result).toEqual(expectedResult.attribution);
 
     rally.shutdown();
   });


### PR DESCRIPTION
Correct pulling of attribution from browser storage, and bump version of attention-stream to `0.5.1`.