### PR TITLE
Remove requestIdleCallback

### DIFF
--- a/web-platform/website/src/services/ExtensionsEventService.ts
+++ b/web-platform/website/src/services/ExtensionsEventService.ts
@@ -30,11 +30,7 @@ export function dispose() {
 }
 
 function sendWebCheck() {
-  // The Rally extension runs the content script on `document_idle`.
-  // This redundant call can be removed when it has been changed to use `document_start`.
-  window.requestIdleCallback(() =>
-    window.dispatchEvent(new CustomEvent("rally-sdk.web-check", {}))
-  );
+  window.dispatchEvent(new CustomEvent("rally-sdk.web-check", {}))
 }
 
 function subscribeToEvents() {

--- a/web-platform/website/src/services/__tests__/ExtensionsEventService.tests.ts
+++ b/web-platform/website/src/services/__tests__/ExtensionsEventService.tests.ts
@@ -16,8 +16,6 @@ describe("ExtensionsEventService tests", () => {
   describe("initializeExtensionEvents tests", () => {
     beforeEach(() => {
       jest.resetAllMocks();
-      // Call idle callback immediately.
-      window.requestIdleCallback = jest.fn().mockImplementation(cb => cb());
 
       dispose();
     });


### PR DESCRIPTION
Closes #473 

We had added a `requestIdleCallback` before doing `web-check` (https://github.com/mozilla-rally/rally/pull/250) because the extension SDK wasn't loading it's content script fast enough (and so the message was getting lost). We fixed the extension so we can remove that callback now.

Also, Safari doesn't support `requestIdleCallback`, so it was breaking Safari (and by extension, iOS).

https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback#browser_compatibility